### PR TITLE
Reduced the number of SQL queries by introducing join fetches

### DIFF
--- a/med-assist-backend/src/main/java/inc/evil/medassist/appointment/web/AppointmentResponse.java
+++ b/med-assist-backend/src/main/java/inc/evil/medassist/appointment/web/AppointmentResponse.java
@@ -1,9 +1,13 @@
 package inc.evil.medassist.appointment.web;
 
 import inc.evil.medassist.appointment.model.Appointment;
+import inc.evil.medassist.doctor.model.Doctor;
 import inc.evil.medassist.doctor.web.DoctorResponse;
 import inc.evil.medassist.patient.web.PatientResponse;
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.stream.Collectors;
 
 @Data
 @Builder
@@ -26,9 +30,22 @@ public class AppointmentResponse {
                 .startTime(appointment.getStartTime().toString())
                 .endTime(appointment.getEndTime().toString())
                 .operation(appointment.getOperation())
-                .doctor(DoctorResponse.from(appointment.getDoctor()))
+                .doctor(makeDoctor(appointment.getDoctor()))
                 .patient(PatientResponse.from(appointment.getPatient()))
                 .details(appointment.getDetails())
+                .build();
+    }
+
+    private static DoctorResponse makeDoctor(Doctor doctor) {
+        return DoctorResponse.builder()
+                .id(doctor.getId())
+                .email(doctor.getEmail())
+                .firstName(doctor.getFirstName())
+                .lastName(doctor.getLastName())
+                .username(doctor.getUsername())
+                .specialty(doctor.getSpecialty().name())
+                .telephoneNumber(doctor.getTelephoneNumber())
+                .enabled(doctor.isEnabled())
                 .build();
     }
 }

--- a/med-assist-backend/src/main/java/inc/evil/medassist/doctor/repository/DoctorRepository.java
+++ b/med-assist-backend/src/main/java/inc/evil/medassist/doctor/repository/DoctorRepository.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 
 import javax.persistence.LockModeType;
 import javax.swing.text.html.Option;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -18,4 +19,10 @@ public interface DoctorRepository extends JpaRepository<Doctor, String> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select d from Doctor d where d.id = :id")
     Doctor findByIdAndLock(@Param("id") String id);
+
+    @Query("select d from Doctor d join fetch d.authorities where d.id = :id")
+    Optional<Doctor> findByIdWithAuthorities(@Param("id") String id);
+
+    @Query("select d from Doctor d join fetch d.authorities")
+    List<Doctor> findAllWithAuthorities();
 }

--- a/med-assist-backend/src/main/java/inc/evil/medassist/doctor/service/DoctorServiceImpl.java
+++ b/med-assist-backend/src/main/java/inc/evil/medassist/doctor/service/DoctorServiceImpl.java
@@ -25,13 +25,13 @@ class DoctorServiceImpl implements DoctorService {
     @Override
     @Transactional(readOnly = true)
     public List<Doctor> findAll() {
-        return doctorRepository.findAll();
+        return doctorRepository.findAllWithAuthorities();
     }
 
     @Override
     @Transactional(readOnly = true)
     public Doctor findById(String id) {
-        return doctorRepository.findById(id)
+        return doctorRepository.findByIdWithAuthorities(id)
                 .orElseThrow(() -> new NotFoundException(Doctor.class, "id", id));
     }
 
@@ -45,7 +45,7 @@ class DoctorServiceImpl implements DoctorService {
     @Override
     @Transactional
     public Doctor update(final String id, final Doctor newDoctorState) {
-        Doctor user = doctorRepository.findById(id).orElseThrow(() -> new NotFoundException(Doctor.class, "id", id));
+        Doctor user = doctorRepository.findByIdWithAuthorities(id).orElseThrow(() -> new NotFoundException(Doctor.class, "id", id));
         if (newDoctorState.getFirstName() != null)
             user.setFirstName(newDoctorState.getFirstName());
         if (newDoctorState.getLastName() != null)

--- a/med-assist-backend/src/main/java/inc/evil/medassist/user/model/User.java
+++ b/med-assist-backend/src/main/java/inc/evil/medassist/user/model/User.java
@@ -8,16 +8,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -51,7 +46,6 @@ public class User extends AbstractEntity implements UserDetails {
 
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Fetch(FetchMode.JOIN)
     private Set<UserAuthority> authorities = new HashSet<>();
 
     @Override

--- a/med-assist-backend/src/main/java/inc/evil/medassist/user/repository/UserRepository.java
+++ b/med-assist-backend/src/main/java/inc/evil/medassist/user/repository/UserRepository.java
@@ -2,12 +2,21 @@ package inc.evil.medassist.user.repository;
 
 import inc.evil.medassist.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, String> {
-    Optional<User> findByUsername(String username);
+    @Query("select u from User u join fetch u.authorities where u.username = :username")
+    Optional<User> findByUsername(@Param("username") String username);
 
+    @Query("select u from User u join fetch u.authorities where u.id = :id")
+    Optional<User> findByIdWithAuthorities(String id);
+
+    @Query("select u from User u join fetch u.authorities")
+    List<User> findAllWithAuthorities();
 }

--- a/med-assist-backend/src/main/java/inc/evil/medassist/user/service/UserServiceImpl.java
+++ b/med-assist-backend/src/main/java/inc/evil/medassist/user/service/UserServiceImpl.java
@@ -26,13 +26,13 @@ class UserServiceImpl implements UserService {
 
     @Override
     public List<User> findAll() {
-        return userRepository.findAll();
+        return userRepository.findAllWithAuthorities();
     }
 
     @Override
     @Transactional(readOnly = true)
     public User findById(final String id) {
-        return userRepository.findById(id).orElseThrow(() -> new NotFoundException(User.class, "id", id));
+        return userRepository.findByIdWithAuthorities(id).orElseThrow(() -> new NotFoundException(User.class, "id", id));
     }
 
     @Override
@@ -63,7 +63,7 @@ class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public User update(final String id, final User newUserState) {
-        User user = userRepository.findById(id).orElseThrow(() -> new NotFoundException(User.class, "id", id));
+        User user = userRepository.findByIdWithAuthorities(id).orElseThrow(() -> new NotFoundException(User.class, "id", id));
         if (newUserState.getFirstName() != null)
             user.setFirstName(newUserState.getFirstName());
         if (newUserState.getLastName() != null)

--- a/med-assist-backend/src/test/java/inc/evil/medassist/appointment/AppointmentComponentTest.java
+++ b/med-assist-backend/src/test/java/inc/evil/medassist/appointment/AppointmentComponentTest.java
@@ -14,8 +14,6 @@ import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.jdbc.Sql;
 
-import java.util.Set;
-
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @ComponentTest
@@ -36,7 +34,6 @@ public class AppointmentComponentTest extends AbstractWebIntegrationTest {
                                 .lastName("Usaci")
                                 .username("vusaci")
                                 .email("vusaci@gmail.com")
-                                .authorities(Set.of("ROLE_DOCTOR"))
                                 .specialty(Specialty.ORTHODONTIST.name())
                                 .telephoneNumber("37369666666")
                                 .enabled(true)
@@ -56,6 +53,41 @@ public class AppointmentComponentTest extends AbstractWebIntegrationTest {
 
         assertThat(response.getStatusCode().value()).isEqualTo(HttpStatus.OK.value());
         assertThat(response.getBody()).isEqualTo(expectedAppointments);
+    }
+
+    @Test
+    @Sql("/test-data/appointment/appointment.sql")
+    public void shouldBeAbleToFindAppointmentsById() {
+        AppointmentResponse expectedAppointment = AppointmentResponse.builder()
+                .id("aa3e4567-e89b-12d3-b457-5267141750aa")
+                .appointmentDate("2021-12-12")
+                .startTime("17:00")
+                .endTime("18:00")
+                .operation("Выдача каппы")
+                .doctor(DoctorResponse.builder()
+                        .id("f23e4567-e89b-12d3-a456-426614174000")
+                        .firstName("Vasile")
+                        .lastName("Usaci")
+                        .username("vusaci")
+                        .email("vusaci@gmail.com")
+                        .specialty(Specialty.ORTHODONTIST.name())
+                        .telephoneNumber("37369666666")
+                        .enabled(true)
+                        .build())
+                .patient(PatientResponse.builder()
+                        .id("f44e4567-ef9c-12d3-a45b-52661417400a")
+                        .firstName("Jim")
+                        .lastName("Morrison")
+                        .birthDate("1994-12-13")
+                        .phoneNumber("+37369952147")
+                        .build())
+                .build();
+        RequestEntity<Void> request = makeAuthenticatedRequestFor("/api/v1/appointments/aa3e4567-e89b-12d3-b457-5267141750aa", HttpMethod.GET);
+
+        ResponseEntity<AppointmentResponse> response = restTemplate.exchange(request, AppointmentResponse.class);
+
+        assertThat(response.getStatusCode().value()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.getBody()).isEqualTo(expectedAppointment);
     }
 
     @Test


### PR DESCRIPTION
The following piece of code has some performance issues.
![image](https://user-images.githubusercontent.com/43374942/146254484-1ee3adaa-f8f0-4844-a9db-f0b6e2611e85.png)

It seems that the `@Fetch(FetchMode.JOIN)` sometimes doesn't join, but executes a separate query. For example if you try to call the `/api/v1/doctors` endpoint (`findAllDoctors`), hibernate executes 2 queries (one for fetching doctors and another one for fetching its authorities):

![image](https://user-images.githubusercontent.com/43374942/146254432-7ce30600-3e93-4eea-8278-1566845ceccf.png)

Clearly this can be written as a single SQL query. 
After switching to `join fetch` strategy, we execute a single query:

![image](https://user-images.githubusercontent.com/43374942/146255034-21d5a242-b0ca-45a7-9136-ac61fbaae23f.png)
