### PR TITLE
feat: Added some indexes

### DIFF
--- a/med-assist-backend/src/main/resources/db/migration/V20211212131700__initial_schema.sql
+++ b/med-assist-backend/src/main/resources/db/migration/V20211212131700__initial_schema.sql
@@ -28,6 +28,8 @@ create table user_authorities
             references users
 );
 
+create index user_id_fk_index on user_authorities(user_id);
+
 create table patients
 (
     id varchar(255) not null
@@ -67,3 +69,5 @@ create table appointments
     constraint doctor_fk foreign key (doctor_id) references doctors (id),
     constraint patient_fk foreign key (patient_id) references patients (id)
 );
+
+create index doctor_id_fk_index on appointments (doctor_id);


### PR DESCRIPTION
According to https://stackoverflow.com/questions/970562/postgres-and-indexes-on-foreign-keys-and-primary-keys PostgreSQL does not create indexes on the referencing side of foreign key relationships.
Added some indexes to speed up some queries. This is not a complete list, we'll need to return to this issue after some time to see if there are more opportunities for indexing.

Here are some examples:
For this query:
```sql
select
    user0_.id as id1_4_0_,
    authoritie1_.id as id1_3_1_,
    user0_.created_at as created_2_4_0_,
    user0_.updated_at as updated_3_4_0_,
    user0_.email_address as email_ad4_4_0_,
    user0_.enabled as enabled5_4_0_,
    user0_.first_name as first_na6_4_0_,
    user0_.last_name as last_nam7_4_0_,
    user0_.password as password8_4_0_,
    user0_.username as username9_4_0_,
    user0_1_.specialty as specialt1_1_0_,
    user0_1_.telephone_number as telephon2_1_0_,
    case
        when user0_1_.id is not null then 1
        when user0_.id is not null then 0
        end as clazz_0_,
    authoritie1_.created_at as created_2_3_1_,
    authoritie1_.updated_at as updated_3_3_1_,
    authoritie1_.authority as authorit4_3_1_,
    authoritie1_.user_id as user_id5_3_1_,
    authoritie1_.user_id as user_id5_3_0__,
    authoritie1_.id as id1_3_0__
from
    users user0_
        left outer join
    doctors user0_1_
    on user0_.id=user0_1_.id
        inner join
    user_authorities authoritie1_
    on user0_.id=authoritie1_.user_id
where
        user0_.username='square-pants-1'
```

Before adding the index:
![image](https://user-images.githubusercontent.com/43374942/146261162-15b72487-1e18-47fd-805b-05c34601c6ef.png)

After adding the index:

![image](https://user-images.githubusercontent.com/43374942/146261254-c0de9ea4-a616-4a50-9b8d-9050f01f9271.png)


For this query:
```sql
select
    appointmen0_.id as id1_0_,
    appointmen0_.created_at as created_2_0_,
    appointmen0_.updated_at as updated_3_0_,
    appointmen0_.appointment_date as appointm4_0_,
    appointmen0_.details as details5_0_,
    appointmen0_.doctor_id as doctor_i9_0_,
    appointmen0_.end_time as end_time6_0_,
    appointmen0_.operation as operatio7_0_,
    appointmen0_.patient_id as patient10_0_,
    appointmen0_.start_time as start_ti8_0_
from
    appointments appointmen0_
where
    appointmen0_.doctor_id='f23e4567-e89b-12d3-a456-426614174000'
  and appointmen0_.appointment_date='2012-12-12'
  and '17:00:00'<appointmen0_.end_time
  and '18:00:00'>appointmen0_.start_time
```
Before adding the index:
![image](https://user-images.githubusercontent.com/43374942/146261729-3bab9365-d426-4b59-8b45-e842476b3c7c.png)

After adding the index:

![image](https://user-images.githubusercontent.com/43374942/146261814-e7b66d15-6e62-4c2d-9d4c-675b789b75cd.png)
