### PR TITLE
feat: Add appointment-time index

### DIFF
--- a/med-assist-backend/src/main/resources/db/migration/V20211212131700__initial_schema.sql
+++ b/med-assist-backend/src/main/resources/db/migration/V20211212131700__initial_schema.sql
@@ -71,3 +71,5 @@ create table appointments
 );
 
 create index doctor_id_fk_index on appointments (doctor_id);
+create index start_time_index on appointments(start_time);
+create index end_time_index on appointments(end_time);


### PR DESCRIPTION
For this query:
```sql
select
    appointmen0_.id as id1_0_,
    appointmen0_.created_at as created_2_0_,
    appointmen0_.updated_at as updated_3_0_,
    appointmen0_.appointment_date as appointm4_0_,
    appointmen0_.details as details5_0_,
    appointmen0_.doctor_id as doctor_i9_0_,
    appointmen0_.end_time as end_time6_0_,
    appointmen0_.operation as operatio7_0_,
    appointmen0_.patient_id as patient10_0_,
    appointmen0_.start_time as start_ti8_0_
from
    appointments appointmen0_
where
    appointmen0_.doctor_id='f23e4567-e89b-12d3-a456-426614174000'
  and appointmen0_.appointment_date='2012-12-12'
  and '17:00:00'<appointmen0_.end_time
  and '18:00:00'>appointmen0_.start_time
```

Before adding index:
![image](https://user-images.githubusercontent.com/43374942/146269438-328367c2-d383-42eb-95a7-32834df91275.png)

After adding index:
![image](https://user-images.githubusercontent.com/43374942/146269062-5c1f2053-8417-4a6f-95e2-dae9e974f859.png)
